### PR TITLE
Prevent showing toolbar when using Japanese IME.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -34,7 +34,8 @@
     <script src="../dist/js/medium-editor.js"></script>
     <script>
         var editor = new MediumEditor('.editable', {
-            buttonLabels: 'fontawesome'
+            buttonLabels: 'fontawesome',
+            japaneseIME: true
         }),
         cssLink = document.getElementById('medium-editor-theme');
 

--- a/dist/js/medium-editor.js
+++ b/dist/js/medium-editor.js
@@ -5398,7 +5398,7 @@ MediumEditor.extensions = {};
 
         init: function () {
             MediumEditor.Extension.prototype.init.apply(this, arguments);
-
+            this.preventCheckState = false;
             this.initThrottledMethods();
 
             if (!this.relativeContainer) {
@@ -5539,6 +5539,9 @@ MediumEditor.extensions = {};
             // Updating the state of the toolbar as things change
             this.subscribe('editableClick', this.handleEditableClick.bind(this));
             this.subscribe('editableKeyup', this.handleEditableKeyup.bind(this));
+            if (this.base.options.japaneseIME) {
+                this.subscribe('editableKeydown', this.handleEditableKeydown.bind(this));
+            }
 
             // Handle mouseup on document for updating the selection in the toolbar
             this.on(this.document.documentElement, 'mouseup', this.handleDocumentMouseup.bind(this));
@@ -5580,7 +5583,17 @@ MediumEditor.extensions = {};
         },
 
         handleEditableKeyup: function () {
-            this.checkState();
+            if (!this.preventCheckState) {
+                this.checkState();
+            }
+        },
+
+        handleEditableKeydown: function (e) {
+            if (this.base.options.japaneseIME && e.keyCode === 229) {
+                this.preventCheckState = true;
+            } else {
+                this.preventCheckState = false;
+            }
         },
 
         handleBlur: function () {

--- a/src/js/extensions/toolbar.js
+++ b/src/js/extensions/toolbar.js
@@ -81,7 +81,7 @@
 
         init: function () {
             MediumEditor.Extension.prototype.init.apply(this, arguments);
-
+            this.preventCheckState = false;
             this.initThrottledMethods();
 
             if (!this.relativeContainer) {
@@ -222,6 +222,9 @@
             // Updating the state of the toolbar as things change
             this.subscribe('editableClick', this.handleEditableClick.bind(this));
             this.subscribe('editableKeyup', this.handleEditableKeyup.bind(this));
+            if (this.base.options.japaneseIME) {
+                this.subscribe('editableKeydown', this.handleEditableKeydown.bind(this));
+            }
 
             // Handle mouseup on document for updating the selection in the toolbar
             this.on(this.document.documentElement, 'mouseup', this.handleDocumentMouseup.bind(this));
@@ -263,7 +266,17 @@
         },
 
         handleEditableKeyup: function () {
-            this.checkState();
+            if (!this.preventCheckState) {
+                this.checkState();
+            }
+        },
+
+        handleEditableKeydown: function (e) {
+            if (this.base.options.japaneseIME && e.keyCode === 229) {
+                this.preventCheckState = true;
+            } else {
+                this.preventCheckState = false;
+            }
         },
 
         handleBlur: function () {


### PR DESCRIPTION
**Before**

Toolbar showing when Japanese IME keydown ENTER.

![awa](https://cloud.githubusercontent.com/assets/293909/14375123/f7f1c230-fd98-11e5-940c-2285a199cb1f.gif)

**Before**

Do not show toolbar

![awa](https://cloud.githubusercontent.com/assets/293909/14375517/e9a0c178-fd9c-11e5-9097-6bccef694f82.gif)

**参考**

http://qiita.com/xtetsuji/items/555a1ef19ed21ee42873
